### PR TITLE
[fix]웹팩 이미지 경로 오류 수정

### DIFF
--- a/fe/src/components/MainContainer/Main/Picker/Result/ResEntity/index.jsx
+++ b/fe/src/components/MainContainer/Main/Picker/Result/ResEntity/index.jsx
@@ -187,7 +187,7 @@ const ResEntity = ({ num, tier, cate }) => {
         return Tier12;
       case 13:
         return Tier13;
-      case 149:
+      case 14:
         return Tier14;
       case 15:
         return Tier15;

--- a/fe/webpack.config.js
+++ b/fe/webpack.config.js
@@ -53,7 +53,7 @@ module.exports = {
         loader: 'file-loader',
         options: {
           name: '[name].[ext]',
-          publicPath: '/',
+          publicPath: '/Images',
           outputPath: '/Images',
         },
       },


### PR DESCRIPTION
# 📙 작업 내역

구현 내용 및 작업 했던 내역

- 웹팩 이미지 경로 오류 해결을 위해 webpack.config.js 의 publicPath, outputPath를 수정했습니다.
- 웹팩 상에서 이미지를 인식시키기위해 경로를 쓰는것이 아닌 import 방식으로 변경했습니다.
- favicon을 설정하기위해      favicon: path.join(__dirname, './src/Images/logo.ico'), 코드를 추가했습니다.

# 작업 유형

- [ ] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

# 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

# 📝 PR 특이 사항

PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- x
